### PR TITLE
Fixed bug showing undefined when the split string is empty

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,7 +20,7 @@ body {
 
 input[type="text"] {
     width: 99.5%;
-    color: white;
+    color: rgb(184, 180, 180);
     background-color: #181818;
     height: 100px;
     display: block;
@@ -39,15 +39,15 @@ input[type="text"] {
     padding: 4px;
     text-align: left;
     background-color: #181818;
-    color: white;
+    color: rgb(184, 180, 180);
 }
 
 .user {
-    color: green
+    color: rgb(4, 128, 0)
 }
 
 .folderview {
-    color: red
+    color: #b4291c
 }
 
 .help {

--- a/src/Terminal-Output/resolvePath.tsx
+++ b/src/Terminal-Output/resolvePath.tsx
@@ -5,6 +5,11 @@ export function resolvePath(currentFolder:string, path:string):[string,string]
 {
     //Very minimal function because we never will have deeper file depth!
     //We can later make it more complicated if needed!
+
+    //TODO (ToluAta):  
+    //dirty check to fix the undefined error 
+    if(path.length == 0) return [currentFolder, "$"]
+
     const pathSplit = path.split("/")
     if(pathSplit.length==1) return [currentFolder,path]
     var stepFolder = currentFolder

--- a/src/Terminal-Output/resolvePath.tsx
+++ b/src/Terminal-Output/resolvePath.tsx
@@ -6,7 +6,7 @@ export function resolvePath(currentFolder:string, path:string):[string,string]
     //Very minimal function because we never will have deeper file depth!
     //We can later make it more complicated if needed!
 
-    //TODO (ToluAta):  
+    //TODO (ToluAta): Normally when you have no string after your command "ls" gets excuted
     //dirty check to fix the undefined error 
     if(path.length == 0) return [currentFolder, "$"]
 


### PR DESCRIPTION
When TAB is pressed nothing happens instead of showing undefined. Also adjusted red color a bit to not hurt in the eyes.